### PR TITLE
fix: drop esm5 build from package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@
 /tmp
 /out-tsc
 /bundles
-/esm5
-/esm2015
+/esm
 
 # dependencies
 /node_modules

--- a/package.json
+++ b/package.json
@@ -8,20 +8,21 @@
   "scripts": {
     "test": "jest --watch",
     "test:ci": "jest",
-    "prebuild": "rimraf {dist,esm5,esm2015}",
+    "prebuild": "rimraf {dist,esm}",
     "build": "run-p 'tsc:*'",
     "tsc:main": "tsc -p tsconfig.json --outDir dist",
-    "tsc:esm5": "tsc -p tsconfig.esm5.json --outDir esm5",
-    "tsc:esm2015": "tsc -p tsconfig.esm2015.json --outDir esm2015",
+    "tsc:esm2015": "tsc -p tsconfig.esm.json --outDir esm",
     "format": "prettier --write 'src/**/*.ts'",
     "format:check": "prettier --check 'src/**/*.ts'",
     "lint": "yarn lint:eslint && yarn format:check",
     "lint:eslint": "eslint 'src/**/*.ts'"
   },
   "main": "dist/index.js",
-  "module": "esm5/index.js",
-  "es2015": "esm2015/index.js",
-  "typings": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./esm/index.js"
+  },
+  "types": "dist/index.d.ts",
   "peerDependencies": {
     "rxjs": "^6.0.0 || ^7.0.0"
   },

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
     "module": "es2015",
   }
 }

--- a/tsconfig.esm2015.json
+++ b/tsconfig.esm2015.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "target": "es2015",
-    "module": "es2015",
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "sourceMap": true,
     "declaration": true,


### PR DESCRIPTION
BREAKING CHANGE: es5 build is no longer shipped.